### PR TITLE
Subprocess installs pyautogui if not there

### DIFF
--- a/pyautogui_check_script.py
+++ b/pyautogui_check_script.py
@@ -1,7 +1,13 @@
 import sys
+import subprocess
+
+#Check to see if pyautogui is installed
 try:
     import pyautogui
-    print("pyautogui installed")
+    print("pyautogui already installed")
+
+#If not installed, use subprocess to send command to shell
 except ImportError:
-    print("Sorry, no dice")
+    print("Installing pyautogui")
+    subprocess.call("pip install pyautogui")
     sys.exit(1)


### PR DESCRIPTION
If "import pyautogui" returns an ImportError, send the command "pip
install pyautogui" to shell, then close shell.